### PR TITLE
fix: parse MODIF.DAT with free-form spacing

### DIFF
--- a/inewave/newave/modelos/modif.py
+++ b/inewave/newave/modelos/modif.py
@@ -83,6 +83,16 @@ class USINA(Register):
     IDENTIFIER_DIGITS = 8
     LINE = Line([IntegerField(4, 9), LiteralField(20, 44)])
 
+    def read(
+        self, file: IO[Any], storage: str = "", *args: Any, **kwargs: Any
+    ) -> bool:
+        line_str = file.readline()
+        parts = line_str.split()
+        codigo = int(parts[1]) if len(parts) > 1 else None
+        nome = " ".join(parts[2:]) if len(parts) > 2 else None
+        self.data = [codigo, nome]
+        return True
+
     @property
     def codigo(self) -> Optional[int]:
         """
@@ -241,11 +251,11 @@ class NUMMAQ(ModifRegister):
         :return: O índice do conjunto de máquinas
         :rtype: Optional[int]
         """
-        return self.data[0]
+        return self.data[1]
 
     @conjunto.setter
     def conjunto(self, t: int) -> None:
-        self.data[0] = t
+        self.data[1] = t
 
     @property
     def numero_maquinas(self) -> Optional[int]:
@@ -255,11 +265,11 @@ class NUMMAQ(ModifRegister):
         :return: O número de máquinas do conjunto
         :rtype: Optional[int]
         """
-        return self.data[1]
+        return self.data[0]
 
     @numero_maquinas.setter
     def numero_maquinas(self, t: int) -> None:
-        self.data[1] = t
+        self.data[0] = t
 
 
 class VAZMIN(ModifRegister):
@@ -374,13 +384,13 @@ class CMONT(ModifRegister):
         self.data[2] = t
 
 
-class VMAXT(Register):
+class VMAXT(ModifRegister):
     """
     Registro que contém uma modificação do volume máximo
     com data.
     """
 
-    __slots__: List[str] = []
+    __slots__ = []
 
     IDENTIFIER = " VMAXT"
     IDENTIFIER_DIGITS = 8
@@ -437,13 +447,13 @@ class VMAXT(Register):
         self.data[3] = t
 
 
-class VMINT(Register):
+class VMINT(ModifRegister):
     """
     Registro que contém uma modificação do volume mínimo
     com data.
     """
 
-    __slots__: List[str] = []
+    __slots__ = []
 
     IDENTIFIER = " VMINT"
     IDENTIFIER_DIGITS = 8
@@ -500,13 +510,13 @@ class VMINT(Register):
         self.data[3] = t
 
 
-class VMINP(Register):
+class VMINP(ModifRegister):
     """
     Registro que contém uma modificação do volume mínimo
     com data para adoção de penalidade.
     """
 
-    __slots__: List[str] = []
+    __slots__ = []
 
     IDENTIFIER = " VMINP"
     IDENTIFIER_DIGITS = 8
@@ -563,13 +573,13 @@ class VMINP(Register):
         self.data[3] = t
 
 
-class VAZMINT(Register):
+class VAZMINT(ModifRegister):
     """
     Registro que contém uma modificação da vazão mínima
     com data.
     """
 
-    __slots__: List[str] = []
+    __slots__ = []
 
     IDENTIFIER = " VAZMINT"
     IDENTIFIER_DIGITS = 8
@@ -611,13 +621,13 @@ class VAZMINT(Register):
         self.data[2] = t
 
 
-class VAZMAXT(Register):
+class VAZMAXT(ModifRegister):
     """
     Registro que contém uma modificação da vazão máxima
     com data.
     """
 
-    __slots__: List[str] = []
+    __slots__ = []
 
     IDENTIFIER = " VAZMAXT"
     IDENTIFIER_DIGITS = 8
@@ -659,13 +669,13 @@ class VAZMAXT(Register):
         self.data[2] = t
 
 
-class TURBMAXT(Register):
+class TURBMAXT(ModifRegister):
     """
     Registro que contém uma modificação da turbinamento máximo
     com data.
     """
 
-    __slots__: List[str] = []
+    __slots__ = []
 
     IDENTIFIER = " TURBMAXT"
     IDENTIFIER_DIGITS = 9
@@ -707,13 +717,13 @@ class TURBMAXT(Register):
         self.data[2] = t
 
 
-class TURBMINT(Register):
+class TURBMINT(ModifRegister):
     """
     Registro que contém uma modificação da turbinamento mínimo
     com data.
     """
 
-    __slots__: List[str] = []
+    __slots__ = []
 
     IDENTIFIER = " TURBMINT"
     IDENTIFIER_DIGITS = 9

--- a/tests/mocks/arquivos/modif.py
+++ b/tests/mocks/arquivos/modif.py
@@ -28,6 +28,13 @@ MockTURBMAXT = " TURBMAXT  1 2020    0.00"
 
 MockTURBMINT = " TURBMINT  1 2020    0.00"
 
+# PDE deck format mocks (different column spacing than NEWAVE)
+MockUSINA_PDE_3DIGIT = " USINA     228                 COLIDER\n"
+MockUSINA_PDE_MULTIWORD = " USINA     4                   FUNIL GRANDE\n"
+MockVMAXT_PDE = " VMAXT     1 2024     80.7 '%'\n"
+MockVMINT_PDE = " VMINT     1 2024    13.23 '%'\n"
+MockVAZMINT_PDE = " VAZMINT   1 2024       79    \n"
+
 MockModif = [
     " P.CHAVE  MODIFICACOES E INDICES\n",
     " XXXXXXXX XXXXXXXXXXXXXXXXXXXXX\n",

--- a/tests/newave/test_modif.py
+++ b/tests/newave/test_modif.py
@@ -1,46 +1,49 @@
 # Rotinas de testes associadas ao arquivo modif.dat do NEWAVE
-from inewave.newave.modelos.modif import (
-    USINA,
-    VOLMIN,
-    VOLMAX,
-    NUMCNJ,
-    NUMMAQ,
-    VAZMIN,
-    CFUGA,
-    CMONT,
-    VMAXT,
-    VMINT,
-    VMINP,
-    VAZMINT,
-    VAZMAXT,
-    TURBMAXT,
-    TURBMINT,
-)
-
-from inewave.newave import Modif
-
 from datetime import datetime
-from tests.mocks.mock_open import mock_open
 from unittest.mock import MagicMock, patch
 
+from inewave.newave import Modif
+from inewave.newave.modelos.modif import (
+    CFUGA,
+    CMONT,
+    NUMCNJ,
+    NUMMAQ,
+    TURBMAXT,
+    TURBMINT,
+    USINA,
+    VAZMAXT,
+    VAZMIN,
+    VAZMINT,
+    VMAXT,
+    VMINP,
+    VMINT,
+    VOLMAX,
+    VOLMIN,
+)
 from tests.mocks.arquivos.modif import (
-    MockModif,
-    MockUSINA,
-    MockVOLMIN,
-    MockVOLMAX,
-    MockNUMCNJ,
-    MockNUMMAQ,
-    MockVAZMIN,
     MockCFUGA,
     MockCMONT,
-    MockVMAXT,
-    MockVMINT,
-    MockVMINP,
-    MockVAZMINT,
-    MockVAZMAXT,
+    MockModif,
+    MockNUMCNJ,
+    MockNUMMAQ,
     MockTURBMAXT,
     MockTURBMINT,
+    MockUSINA,
+    MockUSINA_PDE_3DIGIT,
+    MockUSINA_PDE_MULTIWORD,
+    MockVAZMAXT,
+    MockVAZMIN,
+    MockVAZMINT,
+    MockVAZMINT_PDE,
+    MockVMAXT,
+    MockVMAXT_PDE,
+    MockVMINP,
+    MockVMINT,
+    MockVMINT_PDE,
+    MockVOLMAX,
+    MockVOLMIN,
 )
+from tests.mocks.mock_open import mock_open
 
 ARQ_TESTE = "./tests/mocks/arquivos/__init__.py"
 
@@ -48,9 +51,8 @@ ARQ_TESTE = "./tests/mocks/arquivos/__init__.py"
 def test_registro_usina_modif():
     m: MagicMock = mock_open(read_data="".join(MockUSINA))
     r = USINA()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [1, "CAMARGOS"]
     assert r.codigo == 1
@@ -64,9 +66,8 @@ def test_registro_usina_modif():
 def test_registro_vazmin_modif():
     m: MagicMock = mock_open(read_data="".join(MockVAZMIN))
     r = VAZMIN()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [34]
     assert r.vazao == 34
@@ -77,9 +78,8 @@ def test_registro_vazmin_modif():
 def test_registro_vmaxt_modif():
     m: MagicMock = mock_open(read_data="".join(MockVMAXT))
     r = VMAXT()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [12, 2021, 61.310, "'%'"]
     assert r.data_inicio == datetime(2021, 12, 1)
@@ -96,9 +96,8 @@ def test_registro_vmaxt_modif():
 def test_registro_vazmint_modif():
     m: MagicMock = mock_open(read_data="".join(MockVAZMINT))
     r = VAZMINT()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [10, 2021, 10.00]
     assert r.data_inicio == datetime(2021, 10, 1)
@@ -112,9 +111,8 @@ def test_registro_vazmint_modif():
 def test_registro_volmin_modif():
     m: MagicMock = mock_open(read_data="".join(MockVOLMIN))
     r = VOLMIN()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [15563.63, "'h'"]
     assert r.volume == 15563.63
@@ -128,9 +126,8 @@ def test_registro_volmin_modif():
 def test_registro_volmax_modif():
     m: MagicMock = mock_open(read_data="".join(MockVOLMAX))
     r = VOLMAX()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [55.0, "'%'"]
     assert r.volume == 55.0
@@ -144,9 +141,8 @@ def test_registro_volmax_modif():
 def test_registro_numcnj_modif():
     m: MagicMock = mock_open(read_data="".join(MockNUMCNJ))
     r = NUMCNJ()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [2]
     assert r.numero == 2
@@ -157,25 +153,23 @@ def test_registro_numcnj_modif():
 def test_registro_nummaq_modif():
     m: MagicMock = mock_open(read_data="".join(MockNUMMAQ))
     r = NUMMAQ()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [2, 5]
-    assert r.conjunto == 2
-    r.conjunto = 1
-    assert r.conjunto == 1
-    assert r.numero_maquinas == 5
+    assert r.numero_maquinas == 2
     r.numero_maquinas = 10
     assert r.numero_maquinas == 10
+    assert r.conjunto == 5
+    r.conjunto = 1
+    assert r.conjunto == 1
 
 
 def test_registro_vmint_modif():
     m: MagicMock = mock_open(read_data="".join(MockVMINT))
     r = VMINT()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [10, 2021, 20.0, "'%'"]
     assert r.data_inicio == datetime(2021, 10, 1)
@@ -192,9 +186,8 @@ def test_registro_vmint_modif():
 def test_registro_vminp_modif():
     m: MagicMock = mock_open(read_data="".join(MockVMINP))
     r = VMINP()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [10, 2021, 20.0, "'%'"]
     assert r.data_inicio == datetime(2021, 10, 1)
@@ -211,9 +204,8 @@ def test_registro_vminp_modif():
 def test_registro_cfuga_modif():
     m: MagicMock = mock_open(read_data="".join(MockCFUGA))
     r = CFUGA()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [10, 2021, 5.60]
     assert r.data_inicio == datetime(2021, 10, 1)
@@ -227,9 +219,8 @@ def test_registro_cfuga_modif():
 def test_registro_cmont_modif():
     m: MagicMock = mock_open(read_data="".join(MockCMONT))
     r = CMONT()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [10, 2021, 71.30]
     assert r.data_inicio == datetime(2021, 10, 1)
@@ -243,9 +234,8 @@ def test_registro_cmont_modif():
 def test_registro_vazmaxt_modif():
     m: MagicMock = mock_open(read_data="".join(MockVAZMAXT))
     r = VAZMAXT()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [1, 2020, 0.00]
     assert r.data_inicio == datetime(2020, 1, 1)
@@ -259,9 +249,8 @@ def test_registro_vazmaxt_modif():
 def test_registro_turbmaxt_modif():
     m: MagicMock = mock_open(read_data="".join(MockTURBMAXT))
     r = TURBMAXT()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [1, 2020, 0.00]
     assert r.data_inicio == datetime(2020, 1, 1)
@@ -275,9 +264,8 @@ def test_registro_turbmaxt_modif():
 def test_registro_turbmint_modif():
     m: MagicMock = mock_open(read_data="".join(MockTURBMINT))
     r = TURBMINT()
-    with patch("builtins.open", m):
-        with open("", "") as fp:
-            r.read(fp)
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
 
     assert r.data == [1, 2020, 0.00]
     assert r.data_inicio == datetime(2020, 1, 1)
@@ -326,3 +314,55 @@ def test_leitura_escrita_modif():
     with patch("builtins.open", m_releitura):
         cf2 = Modif.read(ARQ_TESTE)
         assert cf1 == cf2
+
+
+def test_registro_usina_pde_3digit():
+    m: MagicMock = mock_open(read_data="".join(MockUSINA_PDE_3DIGIT))
+    r = USINA()
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
+
+    assert r.codigo == 228
+    assert r.nome == "COLIDER"
+
+
+def test_registro_usina_pde_multiword_name():
+    m: MagicMock = mock_open(read_data="".join(MockUSINA_PDE_MULTIWORD))
+    r = USINA()
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
+
+    assert r.codigo == 4
+    assert r.nome == "FUNIL GRANDE"
+
+
+def test_registro_vmaxt_pde_spacing():
+    m: MagicMock = mock_open(read_data="".join(MockVMAXT_PDE))
+    r = VMAXT()
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
+
+    assert r.data_inicio == datetime(2024, 1, 1)
+    assert r.volume == 80.7
+    assert r.unidade == "'%'"
+
+
+def test_registro_vmint_pde_spacing():
+    m: MagicMock = mock_open(read_data="".join(MockVMINT_PDE))
+    r = VMINT()
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
+
+    assert r.data_inicio == datetime(2024, 1, 1)
+    assert r.volume == 13.23
+    assert r.unidade == "'%'"
+
+
+def test_registro_vazmint_pde_spacing():
+    m: MagicMock = mock_open(read_data="".join(MockVAZMINT_PDE))
+    r = VAZMINT()
+    with patch("builtins.open", m), open("", "") as fp:
+        r.read(fp)
+
+    assert r.data_inicio == datetime(2024, 1, 1)
+    assert r.vazao == 79.0


### PR DESCRIPTION
## Summary

- Convert 7 register classes (VMAXT, VMINT, VMINP, VAZMINT, VAZMAXT, TURBMAXT, TURBMINT) from fixed-column-position parsing (`Register`) to space-delimited parsing (`ModifRegister`), fixing truncated values when column spacing differs across deck variants
- Add custom `read()` to USINA that handles 3+ digit UHE codes and multi-word plant names (e.g., "FUNIL GRANDE")
- Fix NUMMAQ field swap where `conjunto` and `numero_maquinas` properties were mapped to the wrong data indices

Closes #116

## Context

MODIF.DAT is a free-form, space-delimited file, but 8 register classes used hardcoded column offsets for parsing. This worked for standard NEWAVE decks but broke on PDE decks (and any other deck variant with different spacing), causing:
- UHE codes with 3+ digits truncated (228 → 22)
- VMAXT values losing last digit (80.7 → 80.0)
- VMINT values losing last digit (13.23 → 13.20)
- VAZMINT values losing last digit (79 → 7)
- Usina names blank or cut off

## Test plan

- [x] All 17 existing tests pass (backward compatibility with NEWAVE format)
- [x] 5 new unit tests verify PDE-format parsing (3-digit codes, multi-word names, different spacing)
- [x] Integration test with real PDE 2034 deck file from issue #116 (37k lines)
- [x] Round-trip read-write-read test still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)