### PR TITLE
fix para leitura de geração térmica por submercado/patamar no forward

### DIFF
--- a/inewave/newave/modelos/forward.py
+++ b/inewave/newave/modelos/forward.py
@@ -2468,7 +2468,6 @@ class SecaoDadosForward(Section):
         for estagio in range(numero_estagios):
             for serie in range(numero_forwards):
                 indice = estagio * numero_forwards + serie
-                # offset = tamanho_registro * indice
-                offset = int(tamanho_registro) * int(indice)
+                offset = tamanho_registro * indice
                 self.__le_registro(file, offset, indice)
         self.__converte_arrays_em_dataframes()

--- a/inewave/newave/modelos/forward.py
+++ b/inewave/newave/modelos/forward.py
@@ -1643,23 +1643,30 @@ class SecaoDadosForward(Section):
         )
 
     def __converte_array_ute_patamar(self, variavel: np.ndarray) -> Any:
+        usinas_por_submercado: List[np.ndarray] = []
+        patamares_por_submercado: List[np.ndarray] = []
+        inicio_classes = 0
+        for numero_classes in self.numero_classes_termicas_submercados:
+            nomes_submercado = self.nomes_classes_termicas[
+                inicio_classes : inicio_classes + numero_classes
+            ]
+            usinas_por_submercado.append(
+                np.tile(nomes_submercado, self.numero_patamares_carga)
+            )
+            patamares_por_submercado.append(
+                np.repeat(
+                    np.arange(1, self.numero_patamares_carga + 1),
+                    numero_classes,
+                )
+            )
+            inicio_classes += numero_classes
+        usinas = np.concatenate(usinas_por_submercado)
+        patamares = np.concatenate(patamares_por_submercado)
         return self.__converte_array_em_dataframe(
             variavel,
             {
-                "usina": np.tile(
-                    np.tile(
-                        self.nomes_classes_termicas,
-                        self.numero_patamares_carga,
-                    ),
-                    self.__num_simulacoes,
-                ),
-                "patamar": np.tile(
-                    np.repeat(
-                        np.arange(1, self.numero_patamares_carga + 1),
-                        self.total_classes_termicas,
-                    ),
-                    self.__num_simulacoes,
-                ),
+                "usina": np.tile(usinas, self.__num_simulacoes),
+                "patamar": np.tile(patamares, self.__num_simulacoes),
             },
             self.total_classes_termicas * self.numero_patamares_carga,
         )
@@ -2461,6 +2468,7 @@ class SecaoDadosForward(Section):
         for estagio in range(numero_estagios):
             for serie in range(numero_forwards):
                 indice = estagio * numero_forwards + serie
-                offset = tamanho_registro * indice
+                # offset = tamanho_registro * indice
+                offset = int(tamanho_registro) * int(indice)
                 self.__le_registro(file, offset, indice)
         self.__converte_arrays_em_dataframes()

--- a/tests/newave/test_forward.py
+++ b/tests/newave/test_forward.py
@@ -1312,4 +1312,53 @@ def test_atributos_forward():
     assert f.volume_canal_desvio_usina.shape == (972, 5)
 
 
+def test_geracao_termica_agrupada_por_submercado():
+    # NEWAVE escreve geração térmica agrupada por submercado. a implementação
+    # original assumia um agrupamento global das calsses por patamar
+
+    numero_patamares = 3
+    total_classes = sum(NUMERO_CLASSES_TERMICAS_SUBMERCADOS)
+    nomes_classes = [f"UTE{i}" for i in range(total_classes)]
+    nomes_usinas = [f"UHE{i}" for i in range(162)]
+    f = Forward.read(
+        ARQ_FORWARD,
+        tamanho_registro=TAMANHO_REGISTRO,
+        numero_estagios=1,
+        numero_forwards=2,
+        numero_rees=12,
+        numero_submercados=4,
+        numero_total_submercados=5,
+        numero_patamares_carga=numero_patamares,
+        numero_patamares_deficit=1,
+        numero_agrupamentos_intercambio=6,
+        numero_classes_termicas_submercados=NUMERO_CLASSES_TERMICAS_SUBMERCADOS,
+        numero_usinas_hidreletricas=162,
+        lag_maximo_usinas_gnl=2,
+        numero_parques_eolicos_equivalentes=0,
+        numero_estacoes_bombeamento=0,
+        nomes_classes_termicas=nomes_classes,
+        nomes_usinas_hidreletricas=nomes_usinas,
+    )
+
+    # rotulos esperados
+    usinas_esperadas: list = []
+    patamares_esperados: list = []
+    inicio = 0
+    for numero_classes in NUMERO_CLASSES_TERMICAS_SUBMERCADOS:
+        nomes_submercado = nomes_classes[inicio : inicio + numero_classes]
+        for patamar in range(1, numero_patamares + 1):
+            usinas_esperadas.extend(nomes_submercado)
+            patamares_esperados.extend([patamar] * numero_classes)
+        inicio += numero_classes
+
+    bloco = f.geracao_termica.iloc[: total_classes * numero_patamares]
+    assert bloco["usina"].tolist() == usinas_esperadas
+    assert bloco["patamar"].tolist() == patamares_esperados
+
+    # no layout global antigo (patamar variando sobre todas as classes), as
+    # primeiras linhas seriam todas do patamar 1. com o fix, o primeiro 
+    # submercado cobre os demais patamares dentro do intervalo
+    assert not (bloco["patamar"].iloc[:total_classes] == 1).all()
+
+
 # NOTE: Binary file with parametrized read, round-trip requires external dimensions


### PR DESCRIPTION
o nw grava a geração térmica em blocos por submercado, com o patamar variando dentro de cada bloco (para as classes daquele submercado). `__converte_array_ute_patamar` montava os rótulos assumindo o patamar variando sobre todas as classes de uma vez.

adicionado o teste `test_geracao_termica_agrupada_por_submercado` em `tests/newave/test_forward.py`