### PR TITLE
fix: layout do clast.dat e registro em branco no bloco de intercambio do sistema.dat

### DIFF
--- a/inewave/newave/modelos/clast.py
+++ b/inewave/newave/modelos/clast.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 from typing import Any, IO, List, Optional
 
@@ -34,6 +35,16 @@ class BlocoUTEClasT(Section):
         data: Optional[Any] = None,
     ) -> None:
         super().__init__(previous, next, data)
+        self.__numero_anos_planejamento = 5
+        self.__linha = self.__monta_linha(self.__numero_anos_planejamento)
+        self.__cabecalhos: List[str] = []
+
+    # Layout posicional dos campos de custo no clast.dat
+    INICIO_CUSTOS = 29
+    LARGURA_CUSTO = 8
+
+    @classmethod
+    def __monta_linha(cls, numero_anos: int) -> Line:
         campos_ute: List[Field] = [
             IntegerField(4, 1),
             LiteralField(12, 6),
@@ -44,10 +55,35 @@ class BlocoUTEClasT(Section):
             LiteralField(10, 19),
         ]
         campos_custos: List[Field] = [
-            FloatField(8, 29 + 8 * i, 2) for i in range(5)
+            FloatField(
+                cls.LARGURA_CUSTO,
+                cls.INICIO_CUSTOS + cls.LARGURA_CUSTO * i,
+                2,
+            )
+            for i in range(numero_anos)
         ]
-        self.__linha = Line(campos_ute + campos_custos)
-        self.__cabecalhos: List[str] = []
+        return Line(campos_ute + campos_custos)
+
+    @staticmethod
+    def __conta_colunas_custo(template: str) -> Optional[int]:
+        """Conta as colunas de custo na linha de template (` XXXX.XX ...`),
+        que e a fonte de verdade do layout dentro do proprio arquivo."""
+        n = len(re.findall(r"X+\.X+", template))
+        return n if n > 0 else None
+
+    @classmethod
+    def __ajusta_cabecalho(cls, texto: str, n_antigo: int, n_novo: int) -> str:
+        """Replica ou remove colunas do cabecalho para refletir o numero de
+        anos presente nos dados, preservando a quebra de linha original."""
+        corpo = texto.rstrip("\n\r")
+        quebra = texto[len(corpo) :]
+        fim = cls.INICIO_CUSTOS + cls.LARGURA_CUSTO * n_antigo
+        if len(corpo) < fim:
+            return texto
+        unidade = corpo[fim - cls.LARGURA_CUSTO : fim]
+        return (
+            corpo[: cls.INICIO_CUSTOS] + unidade * n_novo + corpo[fim:] + quebra
+        )
 
     def __eq__(self, o: object) -> bool:
         if not isinstance(o, BlocoUTEClasT):
@@ -96,7 +132,16 @@ class BlocoUTEClasT(Section):
         for _ in range(2):
             self.__cabecalhos.append(file.readline())
 
-        self.__numero_anos_planejamento = numero_anos_planejamento
+        # O numero de colunas de custo varia com o horizonte do estudo. A
+        # linha de template (` XXXX.XX ...`) e a fonte de verdade dentro do
+        # proprio arquivo; o argumento so vale como fallback.
+        colunas_template = self.__conta_colunas_custo(self.__cabecalhos[-1])
+        self.__numero_anos_planejamento = (
+            colunas_template
+            if colunas_template is not None
+            else numero_anos_planejamento
+        )
+        self.__linha = self.__monta_linha(self.__numero_anos_planejamento)
 
         # Variáveis auxiliares
         codigo_ute: List[int] = []
@@ -122,10 +167,25 @@ class BlocoUTEClasT(Section):
 
     # Override
     def write(self, file: IO[Any], *args: Any, **kwargs: Any) -> None:  # type: ignore[override]  # signature extends base class
-        for linha in self.__cabecalhos:
-            file.write(linha)
         if not isinstance(self.data, pd.DataFrame):
             raise ValueError("Dados do clast.dat não foram lidos com sucesso")
+
+        # O DataFrame pode ter ganhado ou perdido anos desde a leitura
+        # (extensao de horizonte). O cabecalho precisa acompanhar, senao a
+        # releitura trunca os dados de volta ao layout antigo.
+        numero_anos_dados = int(self.data["indice_ano_estudo"].max())
+        if numero_anos_dados != self.__numero_anos_planejamento:
+            self.__cabecalhos = [
+                self.__ajusta_cabecalho(
+                    c, self.__numero_anos_planejamento, numero_anos_dados
+                )
+                for c in self.__cabecalhos
+            ]
+            self.__linha = self.__monta_linha(numero_anos_dados)
+            self.__numero_anos_planejamento = numero_anos_dados
+
+        for linha in self.__cabecalhos:
+            file.write(linha)
 
         df = self.data.copy()
         for _, linha_usina in (

--- a/inewave/newave/modelos/clast.py
+++ b/inewave/newave/modelos/clast.py
@@ -37,7 +37,11 @@ class BlocoUTEClasT(Section):
         campos_ute: List[Field] = [
             IntegerField(4, 1),
             LiteralField(12, 6),
-            LiteralField(12, 19),
+            # O template do arquivo reserva 10 caracteres para TIPO COMB.
+            # (colunas 20-29). Com largura 12 o campo invadia os dois
+            # primeiros caracteres do primeiro campo de custo, corrompendo
+            # o combustivel de usinas com CVU >= 1000.
+            LiteralField(10, 19),
         ]
         campos_custos: List[Field] = [
             FloatField(8, 29 + 8 * i, 2) for i in range(5)

--- a/inewave/newave/modelos/sistema.py
+++ b/inewave/newave/modelos/sistema.py
@@ -388,15 +388,18 @@ class BlocoIntercambioSubsistema(Section):
                 & (df["ano"] == linha_submercados_sentido["ano"])
             ]
             df_interc = df_interc.sort_values(["data"])
-            if any(
+            mudou_par = any(
                 [
                     linha_submercados_sentido["submercado_de"]
                     != ultimo_subsistema_de,
                     linha_submercados_sentido["submercado_para"]
                     != ultimo_subsistema_para,
-                    linha_submercados_sentido["sentido"] != ultimo_sentido,
                 ]
-            ):
+            )
+            mudou_sentido = (
+                linha_submercados_sentido["sentido"] != ultimo_sentido
+            )
+            if mudou_par:
                 ultimo_subsistema_de = linha_submercados_sentido[
                     "submercado_de"
                 ]
@@ -415,6 +418,12 @@ class BlocoIntercambioSubsistema(Section):
                         ].tolist()
                     )
                 )
+            elif mudou_sentido:
+                # Manual do NEWAVE, secao 3.7, Bloco 3: os grupos de
+                # registros tipo 2 (A->B) e tipo 3 (B->A) sao separados por
+                # um registro em branco, de existencia obrigatoria.
+                ultimo_sentido = linha_submercados_sentido["sentido"]
+                file.write("\n")
             ano = prepara_valor_ano(linha_submercados_sentido["ano"])
             valores = df_interc["valor"].tolist()
             file.write(self.__linha.write([ano] + valores))

--- a/tests/mocks/arquivos/clast.py
+++ b/tests/mocks/arquivos/clast.py
@@ -169,3 +169,21 @@ MockBlocoModificacaoClasT = [
 ]
 
 MockClasT = MockBlocoUTEClasT + MockBlocoModificacaoClasT
+
+# Deck com 4 colunas de custo (caso do PMO NW202701)
+MockBlocoUTEClasT4Anos = [
+    " NUM  NOME CLASSE  TIPO COMB.  CUSTO   CUSTO   CUSTO   CUSTO   \n",
+    " XXXX XXXXXXXXXXXX XXXXXXXXXX XXXX.XX XXXX.XX XXXX.XX XXXX.XX \n",
+    "    1 ANGRA 1      Nuclear      31.17   31.17   31.17   31.17 \n",
+    "  491 CAMPO GRANDE Gas        1314.04 1053.57  949.33  904.59 \n",
+    " 9999\n",
+]
+
+# Deck estendido para 6 anos de horizonte
+MockBlocoUTEClasT6Anos = [
+    " NUM  NOME CLASSE  TIPO COMB.  CUSTO   CUSTO   CUSTO   CUSTO   CUSTO   CUSTO   \n",
+    " XXXX XXXXXXXXXXXX XXXXXXXXXX XXXX.XX XXXX.XX XXXX.XX XXXX.XX XXXX.XX XXXX.XX \n",
+    "    1 ANGRA 1      Nuclear      31.17   31.17   31.17   31.17   31.17   31.17 \n",
+    "  491 CAMPO GRANDE Gas        1314.04 1053.57  949.33  904.59  904.59  904.59 \n",
+    " 9999\n",
+]

--- a/tests/newave/test_clast.py
+++ b/tests/newave/test_clast.py
@@ -110,7 +110,9 @@ def test_tipo_combustivel_nao_invade_campo_custo():
         ct = Clast.read(ARQ_TESTE)
 
     combustiveis = set(ct.usinas["tipo_combustivel"].unique())
-    assert all(not c.strip()[-1].isdigit() for c in combustiveis)
+    assert all(
+        not c.strip() or not c.strip()[-1].isdigit() for c in combustiveis
+    )
 
     daia = ct.usinas.loc[ct.usinas["codigo_usina"] == 153]
     assert daia["tipo_combustivel"].iloc[0].strip() == "Diesel"

--- a/tests/newave/test_clast.py
+++ b/tests/newave/test_clast.py
@@ -166,6 +166,14 @@ def test_leitura_escrita_clast_4_colunas_custo():
     # o cabecalho preservado nao deve ganhar colunas de custo extras
     assert linhas_escritas[1].count("XXXX.XX") == 4
 
+    # round-trip completo: sem a deteccao de colunas, o deck de 4 anos era
+    # lido com uma 5a coluna fantasma e a releitura a perpetuava.
+    m_releitura: MagicMock = mock_open(read_data="".join(linhas_escritas))
+    with patch("builtins.open", m_releitura):
+        ct2 = Clast.read(ARQ_TESTE)
+    assert sorted(ct2.usinas["indice_ano_estudo"].unique()) == [1, 2, 3, 4]
+    assert ct1 == ct2
+
 
 def test_escrita_clast_ajusta_cabecalho_ao_estender_horizonte():
     # Ao acrescentar um ano ao DataFrame, o cabecalho precisa ganhar a

--- a/tests/newave/test_clast.py
+++ b/tests/newave/test_clast.py
@@ -98,3 +98,18 @@ def test_leitura_escrita_clast():
     with patch("builtins.open", m_releitura):
         ct2 = Clast.read(ARQ_TESTE)
         assert ct1 == ct2
+
+
+def test_tipo_combustivel_nao_invade_campo_custo():
+    # Usinas com CVU >= 1000 tinham o primeiro digito do custo capturado
+    # pelo campo de combustivel (largura 12 em vez de 10).
+    m: MagicMock = mock_open(read_data="".join(MockBlocoUTEClasT))
+    with patch("builtins.open", m):
+        ct = Clast.read(ARQ_TESTE)
+
+    combustiveis = set(ct.usinas["tipo_combustivel"].unique())
+    assert all(not c.strip()[-1].isdigit() for c in combustiveis)
+
+    daia = ct.usinas.loc[ct.usinas["codigo_usina"] == 153]
+    assert daia["tipo_combustivel"].iloc[0].strip() == "Diesel"
+    assert daia["valor"].iloc[0] == 1178.85

--- a/tests/newave/test_clast.py
+++ b/tests/newave/test_clast.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, patch
 from tests.mocks.arquivos.clast import MockBlocoUTEClasT
 from tests.mocks.arquivos.clast import MockBlocoModificacaoClasT
 from tests.mocks.arquivos.clast import MockClasT
+from tests.mocks.arquivos.clast import MockBlocoUTEClasT4Anos
+from tests.mocks.arquivos.clast import MockBlocoUTEClasT6Anos
 
 ARQ_TESTE = "./tests/mocks/arquivos/__init__.py"
 
@@ -113,3 +115,83 @@ def test_tipo_combustivel_nao_invade_campo_custo():
     daia = ct.usinas.loc[ct.usinas["codigo_usina"] == 153]
     assert daia["tipo_combustivel"].iloc[0].strip() == "Diesel"
     assert daia["valor"].iloc[0] == 1178.85
+
+
+def test_leitura_clast_4_colunas_custo():
+    m: MagicMock = mock_open(read_data="".join(MockBlocoUTEClasT4Anos))
+    with patch("builtins.open", m):
+        ct = Clast.read(ARQ_TESTE)
+
+    assert sorted(ct.usinas["indice_ano_estudo"].unique()) == [1, 2, 3, 4]
+    assert not ct.usinas["valor"].isna().any()
+    angra = ct.usinas.loc[ct.usinas["codigo_usina"] == 1]
+    assert angra["valor"].tolist() == [31.17, 31.17, 31.17, 31.17]
+
+
+def test_leitura_clast_6_colunas_custo():
+    m: MagicMock = mock_open(read_data="".join(MockBlocoUTEClasT6Anos))
+    with patch("builtins.open", m):
+        ct = Clast.read(ARQ_TESTE)
+
+    assert sorted(ct.usinas["indice_ano_estudo"].unique()) == [1, 2, 3, 4, 5, 6]
+    campo = ct.usinas.loc[ct.usinas["codigo_usina"] == 491]
+    assert campo["valor"].tolist() == [
+        1314.04,
+        1053.57,
+        949.33,
+        904.59,
+        904.59,
+        904.59,
+    ]
+
+
+def test_leitura_escrita_clast_4_colunas_custo():
+    # O bloco de modificacoes e concatenado porque Clast.write() percorre
+    # todas as secoes do arquivo (BlocoUTEClasT e BlocoModificacaoUTEClasT);
+    # sem dados de modificacao, BlocoModificacaoUTEClasT.write() levanta
+    # ValueError - convencao ja existente na biblioteca, independente
+    # do numero de colunas de custo testado aqui.
+    m_leitura: MagicMock = mock_open(
+        read_data="".join(MockBlocoUTEClasT4Anos + MockBlocoModificacaoClasT)
+    )
+    with patch("builtins.open", m_leitura):
+        ct1 = Clast.read(ARQ_TESTE)
+    m_escrita: MagicMock = mock_open(read_data="")
+    with patch("builtins.open", m_escrita):
+        ct1.write(ARQ_TESTE)
+        chamadas = m_escrita.mock_calls
+        linhas_escritas = [
+            chamadas[i].args[0] for i in range(1, len(chamadas) - 1)
+        ]
+    # o cabecalho preservado nao deve ganhar colunas de custo extras
+    assert linhas_escritas[1].count("XXXX.XX") == 4
+
+
+def test_escrita_clast_ajusta_cabecalho_ao_estender_horizonte():
+    # Ao acrescentar um ano ao DataFrame, o cabecalho precisa ganhar a
+    # coluna correspondente, senao a releitura trunca de volta.
+    import pandas as pd
+
+    # Idem: bloco de modificacoes concatenado para que Clast.write() nao
+    # levante ValueError na secao sem dados (ver comentario no teste
+    # anterior).
+    m_leitura: MagicMock = mock_open(
+        read_data="".join(MockBlocoUTEClasT4Anos + MockBlocoModificacaoClasT)
+    )
+    with patch("builtins.open", m_leitura):
+        ct1 = Clast.read(ARQ_TESTE)
+
+    df = ct1.usinas
+    ano_extra = df.loc[df["indice_ano_estudo"] == 4].copy()
+    ano_extra["indice_ano_estudo"] = 5
+    ct1.usinas = pd.concat([df, ano_extra], ignore_index=True)
+
+    m_escrita: MagicMock = mock_open(read_data="")
+    with patch("builtins.open", m_escrita):
+        ct1.write(ARQ_TESTE)
+        chamadas = m_escrita.mock_calls
+        linhas_escritas = [
+            chamadas[i].args[0] for i in range(1, len(chamadas) - 1)
+        ]
+    assert linhas_escritas[0].count("CUSTO") == 5
+    assert linhas_escritas[1].count("XXXX.XX") == 5

--- a/tests/newave/test_sistema.py
+++ b/tests/newave/test_sistema.py
@@ -1,4 +1,5 @@
 # Rotinas de testes associadas ao arquivo sistema.dat do NEWAVE
+import re
 from inewave.newave.modelos.sistema import (
     BlocoNumeroPatamaresDeficit,
     BlocoCustosDeficit,
@@ -137,3 +138,33 @@ def test_leitura_escrita_sistema():
     with patch("builtins.open", m_releitura):
         cf2 = Sistema.read(ARQ_TESTE)
         assert cf1 == cf2
+
+
+def test_escrita_intercambio_usa_registro_em_branco():
+    # Manual do NEWAVE v30.0.2, secao 3.7, Bloco 3: os grupos de registros
+    # tipo 2 (A->B) e tipo 3 (B->A) sao "separados por um registro em
+    # branco, de existencia obrigatoria". O cabecalho tipo 1 nao deve ser
+    # repetido nessa virada.
+    m_leitura: MagicMock = mock_open(read_data="".join(MockSistema))
+    with patch("builtins.open", m_leitura):
+        sist = Sistema.read(ARQ_TESTE)
+
+    m_escrita: MagicMock = mock_open(read_data="")
+    with patch("builtins.open", m_escrita):
+        sist.write(ARQ_TESTE)
+        chamadas = m_escrita.mock_calls
+        linhas = [
+            chamadas[i].args[0] for i in range(1, len(chamadas) - 1)
+        ]
+
+    # Um cabecalho tipo 1 por par de submercados, nao um por sentido.
+    cabecalhos = [
+        line for line in linhas if re.match(r"^\s*\d+\s+\d+\s+\d\s*$", line)
+    ]
+    pares = [tuple(line.split()[:2]) for line in cabecalhos]
+    assert len(pares) == len(set(pares)), (
+        f"cabecalho tipo 1 repetido para o mesmo par: {pares}"
+    )
+
+    # E deve existir ao menos um registro em branco separando os grupos.
+    assert any(line == "\n" for line in linhas)


### PR DESCRIPTION
Três correções encontradas ao usar o inewave para montar um estudo de
extensão de horizonte (5 → 6 anos) sobre um deck de PMO. Cada uma está
em seu próprio commit e são independentes entre si.

## 1. `clast.dat`: campo `tipo_combustivel` invade a coluna de custo

O template do arquivo reserva 10 caracteres para `TIPO COMB.`:

```
 XXXX XXXXXXXXXXXX XXXXXXXXXX XXXX.XX XXXX.XX ...
                   ^--- 10 chars (colunas 20-29)
```

O modelo declarava `LiteralField(12, 19)`, cobrindo os índices 19–30 e
invadindo os dois primeiros caracteres do primeiro campo de custo
(`FloatField(8, 29)`).

Efeito: usinas com CVU ≥ 1000 saem com o combustível corrompido.

```
codigo_usina=491  nome_usina="CAMPO GRANDE"
tipo_combustivel="Gas        1"   valor=1314.04
```

Num deck de PMO isso atingia 82 das 159 usinas. A escrita mascarava o
defeito — o campo de custo sobrescreve os bytes invadidos e o arquivo
sai idêntico —, então o dano ficava restrito ao DataFrame exposto ao
usuário: qualquer agregação por tipo de combustível gera categorias
fantasma.

## 2. `clast.dat`: número de colunas de custo fixo em 5

`campos_custos` usava `range(5)`. O `read()` aceita
`numero_anos_planejamento`, mas a `Line` é montada no `__init__` e
`Clast.read()` nunca repassa o argumento — na prática o valor era
sempre 5.

Decks com 4 colunas ganhavam uma coluna fantasma de `NaN`; decks com
horizonte estendido para 6 anos eram truncados na escrita.

A contagem passa a vir da linha de template (`XXXX.XX`), que já está no
cabeçalho do arquivo, com fallback para o comportamento anterior caso
ela esteja ausente. A escrita também ajusta o cabeçalho quando o
DataFrame ganha ou perde anos.

## 3. `sistema.dat`: registro em branco no bloco de intercâmbio

Manual do NEWAVE v30.0.2, seção 3.7, Bloco 3:

> Os registros tipo 2 e 3 devem ser fornecidos agrupadamente e os grupos
> serão separados por um registro em branco, de existência obrigatória.

O leitor já respeita isso. O escritor repetia o cabeçalho tipo 1 no
lugar do registro em branco. O round-trip dentro do inewave funciona
(o leitor aceita as duas formas), mas o arquivo gerado diverge do
formato documentado.

## Testes

Toda a suíte continua passando (1170 testes). Foram adicionados:

- `test_tipo_combustivel_nao_invade_campo_custo`
- `test_leitura_clast_4_colunas_custo` / `test_leitura_clast_6_colunas_custo`
- `test_leitura_escrita_clast_4_colunas_custo` (round-trip completo)
- `test_escrita_clast_ajusta_cabecalho_ao_estender_horizonte`
- `test_escrita_intercambio_usa_registro_em_branco`

Validação adicional contra um deck de PMO real: round-trip byte-a-byte
idêntico nas 159 usinas do bloco de UTEs do `clast.dat` e no bloco de
intercâmbio do `sistema.dat`.

## Notas de escopo

Dois pontos correlatos ficaram de fora deste PR por não serem
correções isoladas — vou abrir uma issue para discuti-los:

- No bloco de intercâmbio, a coluna `sentido` funde o flag do campo 3 do
  registro tipo 1 (`0` = limite, `1` = intercâmbio mínimo obrigatório)
  com o sentido A→B / B→A, que pelo manual é posicional. Corrigir isso é
  breaking change no DataFrame público.
- No bloco de modificação do `clast.dat`, as datas saem com mês
  zero-padded (`"07 2026"`) onde o original usa espaço (`" 7 2026"`). O
  mesmo `format="%m %Y"` é usado em `agrint.dat` e `expt.dat`, e não há
  correção portável de uma linha (`%_m` é extensão do glibc), então
  prefiro discutir a abordagem antes.