### PR TITLE
fix: separa o flag de intercâmbio mínimo do sentido no bloco de intercâmbio do sistema.dat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ e este projeto adere ao [Versionamento Semantico](https://semver.org/lang/pt-BR/
 
 ## [Não lançado]
 
+### Adicionado
+
+- `sistema.dat`: a tabela de limites de intercâmbio (`Sistema.limites_intercambio`) passa a expor a coluna `flag` (campo 3 do registro tipo 1: `0` = limite, `1` = intercâmbio mínimo obrigatório). Antes essa informação era fundida na coluna `sentido` e se perdia na leitura; agora o par de submercados é representado sem perdas. A coluna `sentido` mantém exatamente os valores anteriores (`flag XOR direção`), então decks apenas com limites não sofrem alteração.
+
 ### Corrigido
 
+- `sistema.dat`: a escrita do bloco de intercâmbio de decks com intercâmbio mínimo obrigatório (`flag` = 1) deixa de inverter os grupos A->B / B->A e de gravar o campo 3 errado. Com a direção derivada de `sentido XOR flag`, o round-trip volta a ser fiel para `flag` = 0 e = 1.
 - `clast.dat`: a largura do campo `tipo_combustivel` foi corrigida de 12 para 10 caracteres. Com 12 o campo invadia a primeira coluna de custo e corrompia o combustível de usinas com CVU ≥ 1000 (o dano ficava restrito ao DataFrame, pois a escrita mascarava o defeito) [#123](https://github.com/rjmalves/inewave/pull/123) (@dcpirex).
 - `clast.dat`: o número de colunas de custo passa a ser detectado da linha de template do próprio arquivo, em vez de fixo em 5, com fallback para o argumento `numero_anos_planejamento`. Suporta decks com 4 colunas e horizontes estendidos (6 anos), ajustando o cabeçalho na escrita quando o número de anos muda [#123](https://github.com/rjmalves/inewave/pull/123) (@dcpirex).
 - `sistema.dat`: a escrita do bloco de intercâmbio passa a emitir o registro em branco obrigatório entre os grupos de sentido (registros tipo 2 e 3), conforme o manual do NEWAVE (seção 3.7, Bloco 3), em vez de repetir o cabeçalho tipo 1 [#123](https://github.com/rjmalves/inewave/pull/123) (@dcpirex).

--- a/inewave/newave/modelos/sistema.py
+++ b/inewave/newave/modelos/sistema.py
@@ -287,6 +287,7 @@ class BlocoIntercambioSubsistema(Section):
                     "submercado_de": repete_vetor(subsistemas_de),
                     "submercado_para": repete_vetor(subsistemas_para),
                     "sentido": repete_vetor(sentidos),
+                    "flag": repete_vetor(flags),
                     "data": prepara_vetor_anos_tabela(anos),  # type: ignore[arg-type]  # numpy array passed where List[str] expected
                     "valor": tabela.flatten(),
                 }
@@ -301,10 +302,16 @@ class BlocoIntercambioSubsistema(Section):
         subsis_de_atual = 0
         subsis_para_atual = 0
         sentido_atual = -1
+        # Campo 3 do registro tipo 1 (0 = limite, 1 = intercâmbio mínimo
+        # obrigatório). É uma propriedade do PAR (A, B), constante nos dois
+        # grupos de sentido. `sentido` guarda `flag XOR direção` por razões
+        # históricas; expor `flag` separadamente torna o par sem perdas.
+        flag_atual = 0
         ano_atual = 0
         subsistemas_de: List[int] = []
         subsistemas_para: List[int] = []
         sentidos: List[int] = []
+        flags: List[int] = []
         anos: List[int] = []
         tabela = np.zeros(
             (
@@ -335,11 +342,15 @@ class BlocoIntercambioSubsistema(Section):
                 subsis_para_atual = (
                     subsis_para_atual if cabecalho[1] is None else cabecalho[1]
                 )
-                sentido_atual = (
-                    cabecalho[2]
-                    if cabecalho[2] is not None
-                    else int(not sentido_atual)
-                )
+                # O campo 3 só existe no registro tipo 1 (cabeçalho do par);
+                # no registro em branco que separa os sentidos ele vem vazio,
+                # e aí o sentido apenas alterna, preservando o comportamento
+                # histórico. O flag do par é mantido nesse intervalo.
+                if cabecalho[2] is not None:
+                    sentido_atual = cabecalho[2]
+                    flag_atual = cabecalho[2]
+                else:
+                    sentido_atual = int(not sentido_atual)
             else:
                 if isinstance(dados[0], int) and dados[0] != ano_atual:
                     ano_atual = dados[0]
@@ -347,6 +358,7 @@ class BlocoIntercambioSubsistema(Section):
                 subsistemas_de.append(subsis_de_atual)
                 subsistemas_para.append(subsis_para_atual)
                 sentidos.append(sentido_atual)
+                flags.append(flag_atual)
                 tabela[i, :] = dados[1:]
                 i += 1
 
@@ -359,72 +371,60 @@ class BlocoIntercambioSubsistema(Section):
 
         ultimo_subsistema_de = 0
         ultimo_subsistema_para = 0
-        ultimo_sentido = -1
+        ultima_direcao = -1
 
-        # Separa os valores de cada submercado, razao, ano
+        # Separa os valores de cada submercado, sentido, ano
         df = self.data.copy()
         df["ano"] = df.apply(lambda linha: linha["data"].year, axis=1)
+        # Direção A->B (0) / B->A (1): posicional no arquivo (grupo antes /
+        # depois do registro em branco). O `sentido` histórico equivale a
+        # `flag XOR direção`, então recuperamos a direção como `sentido XOR
+        # flag`. Para flag=0 (a maioria dos casos) direção == sentido e a
+        # escrita fica idêntica à anterior.
+        df["direcao"] = df["sentido"].astype(int) ^ df["flag"].astype(int)
         # Ordena pelas chaves de agrupamento para que a escrita do cabeçalho
         # (emitido quando a chave muda) independa da ordem das linhas no
         # DataFrame de entrada.
         df = df.sort_values(
-            ["submercado_de", "submercado_para", "sentido", "ano", "data"]
+            ["submercado_de", "submercado_para", "direcao", "ano", "data"]
         )
-        for _, linha_submercados_sentido in (
-            df[["submercado_de", "submercado_para", "sentido", "ano"]]
+        for _, chave in (
+            df[["submercado_de", "submercado_para", "flag", "direcao", "ano"]]
             .drop_duplicates()
             .iterrows()
         ):
             df_interc = df.loc[
-                (
-                    df["submercado_de"]
-                    == linha_submercados_sentido["submercado_de"]
-                )
-                & (
-                    df["submercado_para"]
-                    == linha_submercados_sentido["submercado_para"]
-                )
-                & (df["sentido"] == linha_submercados_sentido["sentido"])
-                & (df["ano"] == linha_submercados_sentido["ano"])
-            ]
-            df_interc = df_interc.sort_values(["data"])
+                (df["submercado_de"] == chave["submercado_de"])
+                & (df["submercado_para"] == chave["submercado_para"])
+                & (df["direcao"] == chave["direcao"])
+                & (df["ano"] == chave["ano"])
+            ].sort_values(["data"])
             mudou_par = any(
                 [
-                    linha_submercados_sentido["submercado_de"]
-                    != ultimo_subsistema_de,
-                    linha_submercados_sentido["submercado_para"]
-                    != ultimo_subsistema_para,
+                    chave["submercado_de"] != ultimo_subsistema_de,
+                    chave["submercado_para"] != ultimo_subsistema_para,
                 ]
             )
-            mudou_sentido = (
-                linha_submercados_sentido["sentido"] != ultimo_sentido
-            )
+            mudou_direcao = chave["direcao"] != ultima_direcao
             if mudou_par:
-                ultimo_subsistema_de = linha_submercados_sentido[
-                    "submercado_de"
-                ]
-                ultimo_subsistema_para = linha_submercados_sentido[
-                    "submercado_para"
-                ]
-                ultimo_sentido = linha_submercados_sentido["sentido"]
+                ultimo_subsistema_de = chave["submercado_de"]
+                ultimo_subsistema_para = chave["submercado_para"]
+                ultima_direcao = chave["direcao"]
+                # Campo 3 do registro tipo 1 = flag do par (limite / mínimo).
                 file.write(
                     self.__linha_subsis.write(
-                        linha_submercados_sentido[
-                            [
-                                "submercado_de",
-                                "submercado_para",
-                                "sentido",
-                            ]
+                        chave[
+                            ["submercado_de", "submercado_para", "flag"]
                         ].tolist()
                     )
                 )
-            elif mudou_sentido:
+            elif mudou_direcao:
                 # Manual do NEWAVE, secao 3.7, Bloco 3: os grupos de
                 # registros tipo 2 (A->B) e tipo 3 (B->A) sao separados por
                 # um registro em branco, de existencia obrigatoria.
-                ultimo_sentido = linha_submercados_sentido["sentido"]
+                ultima_direcao = chave["direcao"]
                 file.write("\n")
-            ano = prepara_valor_ano(linha_submercados_sentido["ano"])
+            ano = prepara_valor_ano(chave["ano"])
             valores = df_interc["valor"].tolist()
             file.write(self.__linha.write([ano] + valores))
 

--- a/inewave/newave/sistema.py
+++ b/inewave/newave/sistema.py
@@ -84,8 +84,14 @@ class Sistema(SectionFile):
         - submercado_de (`int`)
         - submercado_para (`int`)
         - sentido (`int`)
+        - flag (`int`)
         - data (`datetime`)
         - valor (`float`)
+
+        A coluna ``flag`` é o campo 3 do registro tipo 1 (`0` = limite,
+        `1` = intercâmbio mínimo obrigatório), constante por par de
+        submercados. A coluna ``sentido`` mantém o valor histórico
+        (`flag XOR direção`); a direção A->B / B->A é ``sentido XOR flag``.
 
         :return: A duração por mês em um DataFrame.
         :rtype: pd.DataFrame | None

--- a/tests/newave/test_sistema.py
+++ b/tests/newave/test_sistema.py
@@ -1,4 +1,5 @@
 # Rotinas de testes associadas ao arquivo sistema.dat do NEWAVE
+import io
 import re
 from inewave.newave.modelos.sistema import (
     BlocoNumeroPatamaresDeficit,
@@ -153,9 +154,7 @@ def test_escrita_intercambio_usa_registro_em_branco():
     with patch("builtins.open", m_escrita):
         sist.write(ARQ_TESTE)
         chamadas = m_escrita.mock_calls
-        linhas = [
-            chamadas[i].args[0] for i in range(1, len(chamadas) - 1)
-        ]
+        linhas = [chamadas[i].args[0] for i in range(1, len(chamadas) - 1)]
 
     # Um cabecalho tipo 1 por par de submercados, nao um por sentido.
     cabecalhos = [
@@ -168,3 +167,62 @@ def test_escrita_intercambio_usa_registro_em_branco():
 
     # E deve existir ao menos um registro em branco separando os grupos.
     assert any(line == "\n" for line in linhas)
+
+
+def test_bloco_intercambio_flag_e_sentido():
+    # A coluna `flag` (campo 3 do registro tipo 1: 0 = limite,
+    # 1 = intercâmbio mínimo obrigatório) é exposta sem alterar o `sentido`
+    # histórico. Este deck só tem limites, então flag == 0 em todo lugar.
+    m: MagicMock = mock_open(read_data="".join(MockBlocoLimitesIntercambio))
+    b = BlocoIntercambioSubsistema()
+    with patch("builtins.open", m):
+        with open("", "") as fp:
+            b.read(fp)
+
+    df = b.data
+    assert "flag" in df.columns
+    assert set(df["flag"].unique()) == {0}
+    # sentido preservado: no par (1, 2) o grupo A->B (10280) tem sentido 0 e
+    # o grupo B->A (6694) tem sentido 1, exatamente como antes da mudança.
+    p12 = df[(df["submercado_de"] == 1) & (df["submercado_para"] == 2)]
+    assert set(p12[p12["valor"] == 10280.0]["sentido"]) == {0}
+    assert set(p12[p12["valor"] == 6694.0]["sentido"]) == {1}
+
+
+def test_bloco_intercambio_flag_minimo_roundtrip():
+    # Par (1, 2) com campo 3 = 1 (intercâmbio mínimo obrigatório). O flag deve
+    # ser capturado, a direção A->B/B->A (posicional) preservada e o
+    # round-trip estável — cenário que a coluna única `sentido` não cobria.
+    mock_flag1 = [
+        linha.replace("   1   2               0", "   1   2               1")
+        for linha in MockBlocoLimitesIntercambio
+    ]
+    m: MagicMock = mock_open(read_data="".join(mock_flag1))
+    b = BlocoIntercambioSubsistema()
+    with patch("builtins.open", m):
+        with open("", "") as fp:
+            b.read(fp)
+
+    df = b.data
+    p12 = df[(df["submercado_de"] == 1) & (df["submercado_para"] == 2)]
+    assert set(p12["flag"]) == {1}
+    # os demais pares continuam com flag 0
+    outros = df[(df["submercado_de"] != 1) | (df["submercado_para"] != 2)]
+    assert set(outros["flag"]) == {0}
+
+    # Escrita: campo 3 = 1 e grupo A->B (10280) antes do B->A (6694).
+    buf = io.StringIO()
+    b.write(buf)
+    saida = buf.getvalue()
+    assert "   1   2               1" in saida
+    assert 0 < saida.find("10280") < saida.find("6694")
+
+    # Round-trip estável: reler a saída reproduz o mesmo DataFrame.
+    b2 = BlocoIntercambioSubsistema()
+    b2.read(io.StringIO(saida))
+    colunas = list(df.columns)
+    assert (
+        df.sort_values(colunas)
+        .reset_index(drop=True)
+        .equals(b2.data.sort_values(colunas).reset_index(drop=True))
+    )


### PR DESCRIPTION
## Problema

No bloco de limites de intercâmbio do `sistema.dat`, a coluna `sentido` fundia **dois conceitos ortogonais**:

1. **O campo 3 do registro tipo 1** (`0` = limite, `1` = intercâmbio mínimo obrigatório) — uma propriedade do **par** de submercados, informada uma única vez no cabeçalho.
2. **A direção A→B / B→A** — que é **posicional** no arquivo: o grupo antes do registro em branco é A→B, o de depois é B→A.

O leitor semeia `sentido` com o campo 3 e o inverte a cada registro em branco, de modo que `sentido = flag XOR direção`. Isso guarda **um bit** onde existem **dois**.

Consequências para decks com `flag = 1`:

- **A informação do flag se perde na leitura** — ambos os valores de flag produzem o conjunto `{0, 1}` nos dois grupos do par, então não há como recuperar se o par era limite ou mínimo obrigatório.
- **O round-trip corrompe o arquivo** — a escrita ordenava por `sentido` e gravava o campo 3 a partir dele, invertendo os grupos A→B/B→A e gravando o campo 3 errado.

Para `flag = 0` (a grande maioria dos decks) `sentido` coincide com a direção, então o problema não aparecia.

## Correção

Expõe a coluna **`flag`** (campo 3, sem perdas) e mantém `sentido` **exatamente** com os valores anteriores:

- **Leitura**: o campo 3 é capturado em `flag`, constante nos dois grupos do par; `sentido` continua sendo calculado como antes.
- **Escrita**: o campo 3 é gravado a partir de `flag`, e a ordem dos grupos usa a **direção = `sentido XOR flag`** (A→B antes de B→A). Para `flag = 0`, direção `==` sentido e a saída é **byte-idêntica** à anterior.

A direção verdadeira fica derivável pelo usuário como `sentido XOR flag`.

## Compatibilidade

- Decks apenas com limites (`flag = 0`): **`sentido` inalterado** e escrita **byte-idêntica**. A única mudança visível é a nova coluna `flag` (toda `0`).
- Decks com intercâmbio mínimo obrigatório (`flag = 1`): antes com perda de informação e round-trip incorreto, agora corretos.

## Testes

- `test_bloco_intercambio_flag_e_sentido`: no mock (flag 0), a coluna `flag` existe e é toda 0 e o `sentido` mantém os valores históricos (A→B = 0, B→A = 1).
- `test_bloco_intercambio_flag_minimo_roundtrip`: cenário sintético com `flag = 1` — captura do flag, campo 3 = 1 na escrita, grupo A→B antes do B→A e round-trip estável.

Suíte completa: 1172 testes passando; `ruff` e `mypy` limpos.

## Ressalva

O caminho `flag = 1` é validado de forma **sintética** e contra a estrutura documentada no manual (grupo A→B · registro em branco · grupo B→A), pois não havia um deck real de intercâmbio mínimo obrigatório à disposição. A leitura sem perdas do campo 3 é correta independentemente disso; apenas a **ordenação da escrita** para `flag = 1` depende do invariante "grupo A→B primeiro".

🤖 Generated with [Claude Code](https://claude.com/claude-code)